### PR TITLE
fix links and add header

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -12,19 +12,20 @@
           We also do not cost members a fee to join, we only require motivation and a willingness to learn, empowering 
           any student with any background to develop a passion for STEM to build the next generation of engineers.
           </p>
-          <address>
-            <a style="font-weight:bold" href="https://www.thebluealliance.com/team/2508">The Blue Alliance</a>
-          </address>
-          <address>
-            <a style = "font-weight:bold" href = "https://github.com/Armada2508">Github</a>
-          </address>
+          
+        </div>
+        <h3 class="large-header">Links</h3>
+        <div>
+          <a style="font-weight:bold" href="https://www.thebluealliance.com/team/2508" target="_blank">The Blue Alliance</a>
+          <br><br>
+          <a style="font-weight:bold" href="https://github.com/Armada2508" target="_blank">Github</a>
         </div>
       </div>
     </div>
 
     <div class="row">
       <div class="col-lg-12 about-block">
-        <h3 id="contact" class="large-header">Contact</h3>
+        <h3 class="large-header">Contact</h3>
 
         <address>
           <strong>Stillwater Area High School</strong> <br>


### PR DESCRIPTION
Fixes being unable to click the Github link in About and adds a header for the two links.