### PR TITLE
Add wdm back to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem "middleman"
 # Live-reloading plugin
 gem "middleman-livereload"
 
+# For faster file watcher updates on Windows
+gem "wdm", "~> 0.2.0"
+
 # JavaScript
 gem 'middleman-sprockets'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    wdm (0.2.0)
     webrick (1.8.2)
 
 PLATFORMS
@@ -142,6 +143,7 @@ DEPENDENCIES
   middleman-sprockets
   mutex_m
   terser (~> 1.2)
+  wdm (~> 0.2.0)
 
 BUNDLED WITH
    2.5.16


### PR DESCRIPTION
Previously [wdm](https://github.com/Maher4Ever/wdm) no longer built on newer Ruby versions so it was removed but now it has been taken over by a new maintainer and fixed to build on newer Ruby versions :D